### PR TITLE
missing libssl-dev during build

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <url type="repository">https://github.com/WPI-RAIL/rosauth</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>libssl-dev</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>rostest</build_depend>


### PR DESCRIPTION
I'm opening this issue here because it is where I discovered it, but it requires a little bit of input from one of the core developers. I believe an update to the wiki is in order to clarify this in the future.

The test at (https://github.com/WPI-RAIL/rosauth/blob/develop/CMakeLists.txt#L62) uses a header file from `libssl-dev`, and this is not listed in the `package.xml`. Since this file is only compiled for testing, should it be listed as a `build_depend` or a `test_depend`?

If it indeed should be listed as a `test_depend`, I believe an update to https://github.com/ros-infrastructure/bloom is in order, as it currently does not add `test_depend`s to the build requirements for packages.

This is not currently blocking builds on the ubuntu buildfarm because `libssl-dev` is being installed for some (other) reason. On Fedora, I've found that this is not necessarily true, and that we need to list it somewhere here. The question is where...

Looking for input from @tfoote, @wjwwood and/or @dirk-thomas on whether the build-time test dependency should be a `build_depend` or a `test_depend`. Please update the wiki to reflect this.

Thanks!
