### PR TITLE
Added gencpp-dependency for test target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ install(TARGETS ros_mac_authentication
 if(CATKIN_ENABLE_TESTING)
   ## Add gtest based cpp test target and link libraries
   add_executable(ros_mac_authentication_test test/ros_mac_authentication_test.cpp)
+  add_dependencies(ros_mac_authentication_test ${PROJECT_NAME}_gencpp)
   target_link_libraries(ros_mac_authentication_test ${catkin_LIBRARIES} ${GTEST_LIBRARIES} crypto dl pthread)
   add_rostest(test/ros_mac_authentication.test)
 endif()


### PR DESCRIPTION
This commit fixes a 'missing rosauth.h' error during compilation of the test for me. If this is not the appropriate solution, I'd be happy to learn what the real problem is.