### PR TITLE
Look up packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,6 @@ if(CATKIN_ENABLE_TESTING)
   ## Add gtest based cpp test target and link libraries
   add_executable(ros_mac_authentication_test test/ros_mac_authentication_test.cpp)
   add_dependencies(ros_mac_authentication_test ${PROJECT_NAME}_gencpp)
-  target_link_libraries(ros_mac_authentication_test ${catkin_LIBRARIES} ${GTEST_LIBRARIES} ${OPENSSL_LIBRARIES} dl pthread)
+  target_link_libraries(ros_mac_authentication_test ${catkin_LIBRARIES} ${GTEST_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_DL_LIBS} pthread)
   add_rostest(test/ros_mac_authentication.test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosauth)
 
+find_package(OpenSSL REQUIRED)
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
@@ -36,6 +38,7 @@ catkin_package(CATKIN_DEPENDS roscpp message_runtime)
 
 include_directories(
     ${catkin_INCLUDE_DIRS}
+    ${OPENSSL_INCLUDE_DIR}
 )
 
 ## Declare a cpp executable
@@ -43,7 +46,7 @@ add_executable(ros_mac_authentication src/ros_mac_authentication.cpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(ros_mac_authentication
-  ${catkin_LIBRARIES} crypto
+  ${catkin_LIBRARIES} ${OPENSSL_LIBRARIES}
 )
 
 add_dependencies(ros_mac_authentication ${PROJECT_NAME}_gencpp)
@@ -65,6 +68,6 @@ if(CATKIN_ENABLE_TESTING)
   ## Add gtest based cpp test target and link libraries
   add_executable(ros_mac_authentication_test test/ros_mac_authentication_test.cpp)
   add_dependencies(ros_mac_authentication_test ${PROJECT_NAME}_gencpp)
-  target_link_libraries(ros_mac_authentication_test ${catkin_LIBRARIES} ${GTEST_LIBRARIES} crypto dl pthread)
+  target_link_libraries(ros_mac_authentication_test ${catkin_LIBRARIES} ${GTEST_LIBRARIES} ${OPENSSL_LIBRARIES} dl pthread)
   add_rostest(test/ros_mac_authentication.test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(rosauth)
 
 find_package(OpenSSL REQUIRED)
+find_package(Threads REQUIRED)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
@@ -68,6 +69,8 @@ if(CATKIN_ENABLE_TESTING)
   ## Add gtest based cpp test target and link libraries
   add_executable(ros_mac_authentication_test test/ros_mac_authentication_test.cpp)
   add_dependencies(ros_mac_authentication_test ${PROJECT_NAME}_gencpp)
-  target_link_libraries(ros_mac_authentication_test ${catkin_LIBRARIES} ${GTEST_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_DL_LIBS} pthread)
+  target_link_libraries(ros_mac_authentication_test
+    ${catkin_LIBRARIES} ${GTEST_LIBRARIES} ${OPENSSL_LIBRARIES} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT}
+  )
   add_rostest(test/ros_mac_authentication.test)
 endif()


### PR DESCRIPTION
I was crosscompiling rosauth and found out that it was not linking properly against OpenSSL, libdl and pthread. This PR uses the information from CMake to provide the correct paths to the libraries and the header files.