### PR TITLE
use package format 2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>rosauth</name>
   <version>0.1.7</version>
   <description>Server Side tools for Authorization and Authentication of ROS Clients</description>
@@ -18,7 +18,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>rostest</build_depend>
-  
-  <run_depend>message_runtime</run_depend>
-  <run_depend>roscpp</run_depend>
+
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>roscpp</exec_depend>
 </package>


### PR DESCRIPTION
Since format 2 is supported for a long time this shouldn't be a problem.

On the other hand when porting functionality to ROS 2 this will allow to keep the diff smaller.