### PR TITLE
Fix foxy tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,14 @@ if(BUILD_TESTING)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/test/secret.yaml.in"
     "${PARAMETERS_YAML_FILE}"
-    @ONLY)
+    @ONLY
+  )
+
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/valid.secret"
+    "${CMAKE_CURRENT_BINARY_DIR}/valid.secret"
+    COPYONLY
+  )
 
   set(ROS_MAC_AUTHENTICATION_EXECUTABLE $<TARGET_FILE:ros_mac_authentication>)
   set(ROS_MAC_AUTHENTICATION_TEST_EXECUTABLE $<TARGET_FILE:ros_mac_authentication_test>)

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>launch_testing</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/test/ros_mac_authentication_test.py.in
+++ b/test/ros_mac_authentication_test.py.in
@@ -5,6 +5,7 @@ import sys
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import ExecuteProcess
+from launch_ros.actions import Node
 
 from launch_testing.legacy import LaunchTestService
 
@@ -12,12 +13,13 @@ from launch_testing.legacy import LaunchTestService
 def main(argv=sys.argv[1:]):
     ld = LaunchDescription()
 
-    server_action = ExecuteProcess(
-        cmd=[
-            '@ROS_MAC_AUTHENTICATION_EXECUTABLE@',
-            '__params:=@PARAMETERS_YAML_FILE@'],
-        cwd='@CMAKE_CURRENT_BINARY_DIR@')
-    ld.add_action(server_action)
+    server_node = Node(
+      package='rosauth',
+      node_executable='ros_mac_authentication',
+      parameters=['@PARAMETERS_YAML_FILE@']
+    )
+
+    ld.add_action(server_node)
 
     test_action = ExecuteProcess(
         cmd=['@ROS_MAC_AUTHENTICATION_TEST_EXECUTABLE@'],

--- a/test/secret.yaml.in
+++ b/test/secret.yaml.in
@@ -1,3 +1,3 @@
-ros_mac_authentication:
+/**:
     ros__parameters:
-        secret_file_location: "@CMAKE_CURRENT_SOURCE_DIR@/test/valid.secret"
+        secret_file_location: "@CMAKE_CURRENT_BINARY_DIR@/valid.secret"


### PR DESCRIPTION
Some files were not being properly copied by CMakeLists.txt. Additionally, there is a much better way to handle finding the param files in the launch files. Finally, the package was missing a `test_depend` on `launch_testing`.