### PR TITLE
Fix ros_mac_authentication_test.cpp

### DIFF
--- a/test/ros_mac_authentication_test.cpp
+++ b/test/ros_mac_authentication_test.cpp
@@ -46,7 +46,7 @@ TEST(RosHashAuthentication, validAuthentication)
 
   auto result = client->async_send_request(request);
   EXPECT_TRUE(rclcpp::spin_until_future_complete(node, result) ==
-    rclcpp::executor::FutureReturnCode::SUCCESS);
+    rclcpp::FutureReturnCode::SUCCESS);
   auto response = result.get();
   EXPECT_TRUE(response->authenticated);
 }


### PR DESCRIPTION
Hi, thank you for the work.
Tests cannot be built with newer ros versions such as rolling and galactic because the namespace has changed. I fixed it.
```
~/dev/rosauth (ros2=)
$ colcon build --symlink-install 
Starting >>> rosauth 
--- stderr: rosauth                             
In file included from /opt/ros/galactic/src/gtest_vendor/include/gtest/gtest.h:62,
                 from /home/kosuke55/dev/rosauth/test/ros_mac_authentication_test.cpp:3:
/home/kosuke55/dev/rosauth/test/ros_mac_authentication_test.cpp: In member function ‘virtual void RosHashAuthentication_validAuthentication_Test::TestBody()’:
/home/kosuke55/dev/rosauth/test/ros_mac_authentication_test.cpp:49:13: error: ‘executor’ is not a member of ‘rclcpp’; did you mean ‘executors’?
   49 |     rclcpp::executor::FutureReturnCode::SUCCESS);
      |             ^~~~~~~~
/opt/ros/galactic/src/gtest_vendor/include/gtest/internal/gtest-internal.h:1325:34: note: in definition of macro ‘GTEST_TEST_BOOLEAN_’
 1325 |       ::testing::AssertionResult(expression)) \
      |                                  ^~~~~~~~~~
/home/kosuke55/dev/rosauth/test/ros_mac_authentication_test.cpp:48:3: note: in expansion of macro ‘EXPECT_TRUE’
   48 |   EXPECT_TRUE(rclcpp::spin_until_future_complete(node, result) ==
      |   ^~~~~~~~~~~
make[2]: *** [CMakeFiles/ros_mac_authentication_test.dir/build.make:63: CMakeFiles/ros_mac_authentication_test.dir/test/ros_mac_authentication_test.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:150: CMakeFiles/ros_mac_authentication_test.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
---
Failed   <<< rosauth [7.39s, exited with code 2]

Summary: 0 packages finished [7.50s]
  1 package failed: rosauth
  1 package had stderr output: rosauth
```